### PR TITLE
Update page_name in pages and keep track of old page names.

### DIFF
--- a/db_functions.py
+++ b/db_functions.py
@@ -44,10 +44,7 @@ class DBInterface():
         cursor = self.get_cursor()
         existing_pages_query = "select page_id, page_name from pages;"
         cursor.execute(existing_pages_query)
-        existing_pages = set()
-        for row in cursor:
-            existing_pages.add(row['page_id'])
-        return existing_pages
+        return {int(row['page_id']): row['page_name'] for row in cursor}
 
     def existing_funding_entities(self):
         cursor = self.get_cursor()
@@ -219,10 +216,11 @@ class DBInterface():
                                        template=insert_template,
                                        page_size=_DEFAULT_PAGE_SIZE)
 
-    def insert_pages(self, new_pages):
+    def insert_pages(self, new_pages, deprecated_page_name_records):
         cursor = self.get_cursor()
-        insert_page_query = ("INSERT INTO pages(page_id, page_name) VALUES %s "
-                             "on conflict (page_id) do nothing;")
+        insert_page_query = (
+            "INSERT INTO pages(page_id, page_name) VALUES %s on conflict (page_id) "
+            "do update set page_id = EXCLUDED.page_id, page_name = EXCLUDED.page_name;")
         insert_template = "(%(id)s, %(name)s)"
         new_page_list = [x._asdict() for x in new_pages]
 
@@ -238,6 +236,16 @@ class DBInterface():
         psycopg2.extras.execute_values(
             cursor, insert_page_metadata_query, new_page_list,
             template=insert_page_metadata_template, page_size=_DEFAULT_PAGE_SIZE)
+
+        insert_deprecated_page_names_query = (
+            "INSERT INTO deprecated_page_names (page_id, page_name, deprecated_on) VALUES %s;")
+        insert_deprecated_page_names_template = "(%(id)s, %(name)s, DEFAULT)"
+        deprecated_page_names_list = [x._asdict() for x in deprecated_page_name_records]
+        psycopg2.extras.execute_values(cursor,
+                                       insert_deprecated_page_names_query,
+                                       deprecated_page_names_list,
+                                       template=insert_deprecated_page_names_template,
+                                       page_size=_DEFAULT_PAGE_SIZE)
 
 
     def insert_page_metadata(self, new_page_metadata):

--- a/db_functions.py
+++ b/db_functions.py
@@ -224,11 +224,15 @@ class DBInterface():
         insert_template = "(%(id)s, %(name)s)"
         new_page_list = [x._asdict() for x in new_pages]
 
-        psycopg2.extras.execute_values(cursor,
-                                       insert_page_query,
-                                       new_page_list,
-                                       template=insert_template,
-                                       page_size=_DEFAULT_PAGE_SIZE)
+        try:
+            psycopg2.extras.execute_values(cursor,
+                                           insert_page_query,
+                                           new_page_list,
+                                           template=insert_template,
+                                           page_size=_DEFAULT_PAGE_SIZE)
+        except psycopg2.errors.CardinalityViolation as error:
+            logging.warning('%s\n%s\n%s', error, cursor.query.decode(), new_pages)
+
         insert_page_metadata_query = (
             "INSERT INTO page_metadata(page_id, page_owner) VALUES %s "
             "on conflict (page_id) do nothing;")

--- a/db_functions.py
+++ b/db_functions.py
@@ -243,7 +243,7 @@ class DBInterface():
 
         insert_deprecated_page_names_query = (
             "INSERT INTO deprecated_page_names (page_id, page_name, deprecated_on) VALUES %s;")
-        insert_deprecated_page_names_template = "(%(id)s, %(name)s, DEFAULT)"
+        insert_deprecated_page_names_template = "(%(id)s, %(name)s, CURRENT_DATE)"
         deprecated_page_names_list = [x._asdict() for x in deprecated_page_name_records]
         psycopg2.extras.execute_values(cursor,
                                        insert_deprecated_page_names_query,

--- a/generic_fb_collector.py
+++ b/generic_fb_collector.py
@@ -191,8 +191,9 @@ class SearchRunner():
         if page_id not in self.existing_page_ids:
             self.new_pages.add(PageRecord(id=page_id, name=ad.page_name))
             self.existing_page_ids.add(page_id)
-        # If page_id is known, but page_name is different. Store it to update the page name.
-        if (page_id in self.existing_page_id_to_page_name and
+        # If page_id is known, but page_name is different. Store it to update the page name. Ignore
+        # "bad" page_id 0.
+        if (page_id != 0 and page_id in self.existing_page_id_to_page_name and
                 self.existing_page_id_to_page_name[page_id] != ad.page_name):
             self.deprecated_page_name_records.add(
                 PageRecord(id=page_id, name=self.existing_page_id_to_page_name[page_id]))

--- a/generic_fb_collector.py
+++ b/generic_fb_collector.py
@@ -122,11 +122,13 @@ class SearchRunner():
         self.new_ads = set()
         self.new_funding_entities = set()
         self.new_pages = set()
+        self.deprecated_page_name_records = set()
         self.new_regions = set()
         self.new_impressions = set()
         self.new_ad_region_impressions = list()
         self.new_ad_demo_impressions = list()
-        self.existing_pages = set()
+        self.existing_page_id_to_page_name = dict()
+        self.existing_page_ids = set()
         self.existing_funding_entities = set()
         self.existing_ads_to_end_time_map = dict()
         self.total_ads_added_to_db = 0
@@ -185,9 +187,20 @@ class SearchRunner():
             self.new_funding_entities.add((ad.funding_entity,))
 
     def process_page(self, ad):
-            if int(ad.page_id) not in self.existing_pages:
-                self.new_pages.add(PageRecord(ad.page_id, ad.page_name))
-                self.existing_pages.add(int(ad.page_id))
+        page_id = int(ad.page_id)
+        if page_id not in self.existing_page_ids:
+            self.new_pages.add(PageRecord(id=page_id, name=ad.page_name))
+            self.existing_page_ids.add(page_id)
+        # If page_id is known, but page_name is different. Store it to update the page name.
+        if (page_id in self.existing_page_id_to_page_name and
+                self.existing_page_id_to_page_name[page_id] != ad.page_name):
+            self.deprecated_page_name_records.add(
+                PageRecord(id=page_id, name=self.existing_page_id_to_page_name[page_id]))
+            # Store new name as a new page so that it is updated.
+            self.new_pages.add(PageRecord(id=page_id, name=ad.page_name))
+            logging.info(
+                'Page name for page_id %d changned. Old: \'%s\' new: \'%s\' (from ad ID: %s',
+                page_id, self.existing_page_id_to_page_name[page_id], ad.page_name, ad.archive_id)
 
     def process_ad(self, ad):
         if ad.archive_id not in self.existing_ads_to_end_time_map:
@@ -250,7 +263,8 @@ class SearchRunner():
 
         #cache of ads/pages/regions/demo_groups we've already seen so we don't reinsert them
         self.existing_ads_to_end_time_map = self.db.existing_ads()
-        self.existing_pages = self.db.existing_pages()
+        self.existing_page_id_to_page_name = self.db.existing_pages()
+        self.existing_page_ids = set(self.existing_page_id_to_page_name.keys())
         self.existing_funding_entities = self.db.existing_funding_entities()
 
         #get ads
@@ -272,6 +286,7 @@ class SearchRunner():
             self.new_ad_sponsors = set()
             self.new_funding_entities = set()
             self.new_pages = set()
+            self.deprecated_page_name_records = set()
             self.new_regions = set()
             self.new_impressions = set()
             self.new_ad_region_impressions = list()
@@ -407,7 +422,7 @@ class SearchRunner():
     def write_results(self):
         #write new pages, regions, and demo groups to self.db first so we can update our caches before writing ads
         self.db.insert_funding_entities(self.new_funding_entities)
-        self.db.insert_pages(self.new_pages)
+        self.db.insert_pages(self.new_pages, self.deprecated_page_name_records)
 
         #write new ads to our database
         num_new_ads = len(self.new_ads)

--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -100,6 +100,12 @@ CREATE TABLE page_metadata (
   PRIMARY KEY (page_id),
   CONSTRAINT page_id_fk FOREIGN KEY (page_id) REFERENCES pages (page_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
 );
+CREATE TABLE deprecated_page_names (
+  page_id bigint NOT NULL,
+  page_name character varying NOT NULL,
+  deprecated_on date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
 CREATE TABLE ad_snapshot_metadata (
   archive_id bigint NOT NULL,
   needs_scrape boolean DEFAULT TRUE,
@@ -230,6 +236,11 @@ EXECUTE PROCEDURE moddatetime(last_modified_time);
 
 CREATE TRIGGER page_metadata_moddatetime
 BEFORE UPDATE ON page_metadata
+FOR EACH ROW
+EXECUTE PROCEDURE moddatetime(last_modified_time);
+
+CREATE TRIGGER deprecated_page_names_moddatetime
+BEFORE UPDATE ON deprecated_page_names
 FOR EACH ROW
 EXECUTE PROCEDURE moddatetime(last_modified_time);
 

--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -103,7 +103,7 @@ CREATE TABLE page_metadata (
 CREATE TABLE deprecated_page_names (
   page_id bigint NOT NULL,
   page_name character varying NOT NULL,
-  deprecated_on date DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  deprecated_on date DEFAULT CURRENT_DATE NOT NULL,
   last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
   CONSTRAINT page_id_fk FOREIGN KEY (page_id) REFERENCES pages (page_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
 );

--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -104,7 +104,8 @@ CREATE TABLE deprecated_page_names (
   page_id bigint NOT NULL,
   page_name character varying NOT NULL,
   deprecated_on date DEFAULT CURRENT_TIMESTAMP NOT NULL,
-  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+  last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+  CONSTRAINT page_id_fk FOREIGN KEY (page_id) REFERENCES pages (page_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION
 );
 CREATE TABLE ad_snapshot_metadata (
   archive_id bigint NOT NULL,


### PR DESCRIPTION
when an ad with a known page_id has a page_name different than the currently know page name update the name in pages, and add the old name to deprecated_page_names