### PR TITLE
install facebook-sdk package from github instead of pypi

### DIFF
--- a/active_ads_fb_collector.py
+++ b/active_ads_fb_collector.py
@@ -46,7 +46,7 @@ class SearchRunner():
 
     def run_search(self):
         #get ads
-        graph = facebook.GraphAPI(access_token=self.fb_access_token, version="7.0")
+        graph = facebook.GraphAPI(access_token=self.fb_access_token, version='7.0')
         has_next = True
         next_cursor = ""
         backoff_multiplier = 1

--- a/active_ads_fb_collector.py
+++ b/active_ads_fb_collector.py
@@ -46,7 +46,7 @@ class SearchRunner():
 
     def run_search(self):
         #get ads
-        graph = facebook.GraphAPI(access_token=self.fb_access_token)
+        graph = facebook.GraphAPI(access_token=self.fb_access_token, version="7.0")
         has_next = True
         next_cursor = ""
         backoff_multiplier = 1

--- a/generic_fb_collector.py
+++ b/generic_fb_collector.py
@@ -345,7 +345,7 @@ class SearchRunner():
         self.existing_funding_entities = self.db.existing_funding_entities()
 
         #get ads
-        graph = facebook.GraphAPI(access_token=self.fb_access_token, version="7.0")
+        graph = facebook.GraphAPI(access_token=self.fb_access_token, version='7.0')
         has_next = True
         next_cursor = ""
         backoff_multiplier = 1

--- a/generic_fb_collector.py
+++ b/generic_fb_collector.py
@@ -345,7 +345,7 @@ class SearchRunner():
         self.existing_funding_entities = self.db.existing_funding_entities()
 
         #get ads
-        graph = facebook.GraphAPI(access_token=self.fb_access_token)
+        graph = facebook.GraphAPI(access_token=self.fb_access_token, version="7.0")
         has_next = True
         next_cursor = ""
         backoff_multiplier = 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cffi==1.14.0
 chardet==3.0.4
 cryptography==2.9.1
 dhash==1.3
-facebook-sdk==3.1.0
+-e git+https://github.com/mobolic/facebook-sdk.git@1b92aafa010b88ef511f2f04fc53715f0c3a596b#egg=facebook_sdk
 google-api-core==1.17.0
 google-auth==1.14.1
 google-cloud-core==1.3.0


### PR DESCRIPTION
Pypi version only supports GraphAPI version 3.1 and below, but that version will be turned down Oct 27, 2020.
The latest version from github supports currently supported facebook API versions up to 7.0