### PR TITLE
increase precision in spend_percentage in demo_impressions and region_impressions tables

### DIFF
--- a/sql/unified_schema.sql
+++ b/sql/unified_schema.sql
@@ -148,7 +148,7 @@ CREATE TABLE demo_impressions (
   archive_id bigint,
   age_group character varying,
   gender character varying,
-  spend_percentage decimal(5, 2),
+  spend_percentage decimal(7, 6),
   last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
   CONSTRAINT archive_id_fk FOREIGN KEY (archive_id) REFERENCES ads (archive_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
   CONSTRAINT spend_is_percentage check (
@@ -160,7 +160,7 @@ CREATE TABLE demo_impressions (
 CREATE TABLE region_impressions (
   archive_id bigint,
   region character varying,
-  spend_percentage decimal(5, 2),
+  spend_percentage decimal(7, 6),
   last_modified_time timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
   CONSTRAINT archive_id_fk FOREIGN KEY (archive_id) REFERENCES ads (archive_id) MATCH SIMPLE ON UPDATE NO ACTION ON DELETE NO ACTION,
   CONSTRAINT spend_is_percentage check (


### PR DESCRIPTION
Facebook API returns percentage in form of X.XXXXXX. Therefore using precision 7, and scale 6 (ie up to 6 digits after decimal point)